### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   },
   "scripts": {
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist",
+    "build": "mkdir -p dist && cp index.html dist/ && cp -r src dist/"
   },
   "devDependencies": {
     "gh-pages": "^6.1.1"
   }
 }
+


### PR DESCRIPTION
this will help the build script to work now that you're not using vite. The reason the previous build didn't work is there was no config for vite.